### PR TITLE
*tiny* regex fix

### DIFF
--- a/lib/stanford-core-nlp.rb
+++ b/lib/stanford-core-nlp.rb
@@ -12,7 +12,7 @@ module StanfordCoreNLP
   # The default path for the JAR files 
   # is the gem's bin folder.
   self.jar_path = File.dirname(__FILE__).
-  gsub('/lib', '') + '/bin/'
+  gsub(/\/lib\z/, '') + '/bin/'
   
   # Load the JVM with a minimum heap size of 512MB,
   # and a maximum heap size of 1024MB.


### PR DESCRIPTION
Dear Louis,

Thank you so much for your invaluable library: I've been using it on Windows (not my choice) and in so doing noticed this little problem. Windows's default Ruby install path includes 'C:\Ruby193\lib' in the path for gems: your gsub killed that and caused mysterious errors. The changed regex ensures that lib is only removed at the end of the path.

Hope all's well, and thank you again for this (and for treat!),
Will
