### PR TITLE
Added custom properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.DS_Store
 *swp
 *.gem
+.bundle/

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source :rubygems
 
+gem "fuubar"
+
 gemspec

--- a/lib/stanford-core-nlp.rb
+++ b/lib/stanford-core-nlp.rb
@@ -57,7 +57,7 @@ module StanfordCoreNLP
 
   require 'stanford-core-nlp/bridge'
   extend StanfordCoreNLP::Bridge
-  
+
   class << self
     # The model file names for a given language.
     attr_accessor :model_files
@@ -65,13 +65,18 @@ module StanfordCoreNLP
     attr_accessor :model_path
     # Store the language currently being used.
     attr_accessor :language
+
+    # Custom properties
+    attr_accessor :custom_properties
   end
+
+  self.custom_properties = {}
 
   # The path to the main folder containing the folders
   # with the individual models inside. By default, this
   # is the same as the JAR path.
   self.model_path = self.jar_path
-  
+
   # ########################### #
   # Public configuration params #
   # ########################### #
@@ -102,7 +107,7 @@ module StanfordCoreNLP
 
   # Use english by default.
   self.use :english
-  
+
   # Set a model file.
   def self.set_model(name, file)
     n = name.split('.')[0].intern
@@ -114,7 +119,7 @@ module StanfordCoreNLP
   # ########################### #
 
   def self.bind
-    
+
     # Take care of Windows users.
     if self.running_on_windows?
       self.jar_path.gsub!('/', '\\')
@@ -129,16 +134,16 @@ module StanfordCoreNLP
       klass = const_get(info.first)
       self.inject_get_method(klass)
     end
-  
+
   end
-  
+
   # Load a StanfordCoreNLP pipeline with the
   # specified JVM flags and StanfordCoreNLP
   # properties.
   def self.load(*annotators)
-    
+
     self.bind unless self.bound
-    
+
     # Prepend the JAR path to the model files.
     properties = {}
     self.model_files.each do |k,v|
@@ -156,7 +161,7 @@ module StanfordCoreNLP
       end
       properties[k] = f
     end
-    
+
     properties['annotators'] = annotators.map { |x| x.to_s }.join(', ')
 
     unless self.language == :english
@@ -168,45 +173,46 @@ module StanfordCoreNLP
       # Otherswise throws java.lang.NullPointerException: null.
       properties['parse.buildgraphs'] = 'false'
     end
-    
+
     # Bug fix for NER system. Otherwise throws:
     # Error initializing binder 1 at edu.stanford.
     # nlp.time.Options.<init>(Options.java:88)
     properties['sutime.binders'] = '0'
-    
+
     # Manually include SUTime models.
     if annotators.include?(:ner)
-      properties['sutime.rules'] = 
+      properties['sutime.rules'] =
       self.model_path + 'sutime/defs.sutime.txt, ' +
       self.model_path + 'sutime/english.sutime.txt'
     end
-    
+
     props = get_properties(properties)
-    
+
     # Hack for Java7 compatibility.
     bridge = const_get(:AnnotationBridge)
     bridge.getPipelineWithProperties(props)
 
   end
-  
+
   # Hack in order not to break backwards compatibility.
   def self.const_missing(const)
     if const == :Text
       puts "WARNING: StanfordCoreNLP::Text has been deprecated." +
       "Please use StanfordCoreNLP::Annotation instead."
       Annotation
-    else 
+    else
       super(const)
     end
   end
 
   private
-  
+
   # Create a java.util.Properties object from a hash.
   def self.get_properties(properties)
+    properties = properties.merge(self.custom_properties)
     props = Properties.new
     properties.each do |property, value|
-      props.set_property(property, value)
+      props.set_property(property.to_s, value.to_s)
     end
     props
   end

--- a/spec/english_spec.rb
+++ b/spec/english_spec.rb
@@ -2,11 +2,11 @@
 require_relative 'spec_helper'
 
 describe StanfordCoreNLP do
-  
+
   context "when the whole pipeline is run on an English text" do
-    
+
     it "should get the correct sentences, tokens, POS tags, lemmas and syntactic tree" do
-      
+
       StanfordCoreNLP.use(:english)
       StanfordCoreNLP.set_model('pos.model', 'english-left3words-distsim.tagger')
       StanfordCoreNLP.set_model('parse.model', 'englishPCFG.ser.gz')
@@ -14,7 +14,7 @@ describe StanfordCoreNLP do
       pipeline = StanfordCoreNLP.load(:tokenize, :ssplit, :pos, :lemma, :parse, :ner, :dcoref)
       text = StanfordCoreNLP::Annotation.new(text)
       pipeline.annotate(text)
-      
+
       sentences, tokens, tags, lemmas, begin_char, last_char, name_tags, coref_ids = *get_information(text, true, true)
 
       sentences.should eql ['Angela Merkel met Nicolas Sarkozy on January 25th in Berlin to discuss a new austerity package.']
@@ -26,7 +26,7 @@ describe StanfordCoreNLP do
       name_tags.should eql ["PERSON", "PERSON", "O", "PERSON", "PERSON", "O", "DATE", "DATE", "O", "LOCATION", "O", "O", "O", "O", "O", "O", "O"]
       coref_ids.should eql ["", "1", "", "", "5", "", "3", "", "", "4", "", "", "", "", "", "6", ""]
     end
-    
+
   end
 
 end


### PR DESCRIPTION
Added StanfordNLP::custom_properties so that knowledgeable users can add properties to the processing queue. I needed something this to constrain the maximum sentence length and monkeypatched get_properties, but something like this would be cleaner.
